### PR TITLE
修复配置文件可能带尾换行导致 cookie 错误的问题

### DIFF
--- a/SenKongDao.py
+++ b/SenKongDao.py
@@ -23,8 +23,9 @@ time.sleep(SLEEP_TIME)
 for cookie_line in cookie_lines:
 
     # 准备签到信息
-    uid = cookie_line.split("&")[0]
-    signing_cookie = cookie_line.split("&")[1]
+    configs = cookie_line.split("&")
+    uid = configs[0].strip()
+    signing_cookie = configs[1].strip()
     headers = {
         "user-agent": "Skland/1.0.1 (com.hypergryph.skland; build:100001014; Android 25; ) Okhttp/4.11.0",
         "cred": signing_cookie


### PR DESCRIPTION
一些编辑器可能会自动加尾换行，导致 cred 尾部带 `\n`，统一 strip 处理

![image](https://github.com/Maojuan-lang/SenKongDao/assets/24877906/5072c08b-285c-4119-bd13-4d78232b73fc)
