### PR TITLE
添加支持Github Actions 执行定时任务

### DIFF
--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -1,0 +1,37 @@
+name: SenKongDao Daily Schedule Workflow
+
+on:
+  schedule:
+    - cron: '0 20 * * *'  # UTC+8=凌晨4点
+  workflow_dispatch:      # 添加手动触发事件
+
+jobs:
+  run-python-job:
+    runs-on: ubuntu-latest
+
+    env:
+      UID: ${{ secrets.UID }}
+      ATOKEN: ${{ secrets.ATOKEN }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run Python script
+      if: github.event_name == 'schedule'
+      run: python SenKongDao.py
+
+    - name: Manual Test Step
+      if: github.event_name == 'workflow_dispatch'
+      run: python SenKongDao.py

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@
 
 xxxxxx&yyyyyyyyyy
 
+### 使用 Github Actions 定时运行执行签到
+ 1. 首先 fork 仓库到自己账号下
+ 2. 设置 `UID` 和 `TOKEN`
+ 3. 你可以参考上面教程新建 `SenKongDao_config.txt` 文件，填入 `uid` 以及 `TOKEN` 字段（不推荐，如非必要请在私人仓库这么做）
+ 4. 或者在自己项目页面，依次点击 Settings → Secrets → Secrets and variables → Actions，
+    点击 New repository secret，并创建 `UID` 和 `TOKEN`，填写值，`UID` 与 `TOKEN` 值一一对应，对于多账号则依次换行填写。
+    最后在项目中点击 Actions，`(Enable workflow)` 启动对应的 Actions 即可每日自动签到
+ 5. 若要手动运行，找到对应的 Actions 并点击 Run workflow 即可立即运行
+
 ### 或使用 docker 运行
  1. 参考上面教程新建 `SenKongDao_config.txt` 文件，填入 `uid` 以及 `cred` 字段
  2. 运行 `docker run -v ./SenKongDao_config.txt:/app/SenKongDao_config.txt maojuan180/senkongdao` 其中 `./SenKongDao_config.txt` 为配置文件路径，可自行修改


### PR DESCRIPTION
Github Actions 每月有免费 2000 分钟额度的运行时间，在 Linux 中运行此 python3 签到脚本大致花费 1 分钟（不足 1 分钟记为 1 分钟）。

可自己开关定时任务 `Enable/Disable workflow`，也可手动立即运行 Actions(`Run workflow`)

(可选) 需要在 Settings 中设置 UID 和 ATOKEN 值。
<img width="1123" alt="image" src="https://github.com/Maojuan-lang/SenKongDao/assets/47412509/897f8116-3d3d-44c3-8210-d1ff72cf84ca">

以下为运行成功图：
<img width="1418" alt="image" src="https://github.com/Maojuan-lang/SenKongDao/assets/47412509/e03de5b5-81ed-4b31-b5a4-f66cf32e3560">
定时任务：
<img width="768" alt="image" src="https://github.com/Maojuan-lang/SenKongDao/assets/47412509/4fecae37-9575-4d6c-b7ee-5fe39961bda8">
手动运行：
<img width="912" alt="image" src="https://github.com/Maojuan-lang/SenKongDao/assets/47412509/7acf3331-5fbd-493d-a330-669ca4265ac3">



